### PR TITLE
Fix tests

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,13 @@
 <ruleset name="Laminas coding standard">
     <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
 
+    <!-- Bumping line limit, as URL for license is one character longer -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="121"/>
+        </properties>
+    </rule>
+
     <!-- Paths to check -->
     <file>config</file>
     <file>src</file>

--- a/src/SwaggerUiControllerFactory.php
+++ b/src/SwaggerUiControllerFactory.php
@@ -37,7 +37,11 @@ class SwaggerUiControllerFactory implements FactoryInterface
             ));
         }
 
-        return new SwaggerUiController($container->has(ApiFactory::class) ? $container->get(ApiFactory::class) : $container->get(\ZF\Apigility\Documentation\ApiFactory::class));
+        $apiFactory = $container->has(ApiFactory::class)
+            ? $container->get(ApiFactory::class)
+            : $container->get(\ZF\Apigility\Documentation\ApiFactory::class);
+
+        return new SwaggerUiController($apiFactory);
     }
 
     /**

--- a/test/TestAsset/fixtures/swagger2.json
+++ b/test/TestAsset/fixtures/swagger2.json
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "title": "Test",
-        "version": "1.0"
+        "version": 1
     },
     "tags": [{
             "name": "BooBaz"


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Fix line length causing cs issue (similar to https://github.com/laminas-api-tools/api-tools-documentation-apiblueprint - file level docblocks still cause issues)

Fixed tests failing in newer versions of phpunit where string '1.0' and int 1 are not equal